### PR TITLE
Introduced flaks

### DIFF
--- a/api.py
+++ b/api.py
@@ -1,0 +1,15 @@
+from flask import Flask, jsonify, Response
+import threading
+from lib import dht
+
+class api:
+    def __init__(self, dht: dht):
+        self.dht = dht
+        self.app = Flask(__name__)
+        self.app.add_url_rule("/dht", "dht", self.get_dht_data)
+    
+    def run_async(self):
+        threading.Thread(target=self.app.run, args=()).start()
+
+    def get_dht_data(self):
+        return Response(self.dht.data.toJSON(), mimetype="application/json")

--- a/container.py
+++ b/container.py
@@ -1,14 +1,15 @@
 from dependency_injector import containers, providers
-from dependency_injector.wiring import Provide, inject
 from lib import dht, lcd, clock
+from api import api
 import board
 
 class Container(containers.DeclarativeContainer):
-
+    """
+    Check following url for documetation
+    https://python-dependency-injector.ets-labs.org/
+    """
     config = providers.Configuration()
     lcd = providers.Singleton(lcd)
     clock = providers.Singleton(clock, lcd)
-    dht = providers.Singleton(
-        dht,
-        dht_pin=board.D26
-    )
+    dht = providers.Singleton(dht, dht_pin=board.D26)
+    api = providers.Singleton(api, dht)

--- a/lib/dht.py
+++ b/lib/dht.py
@@ -2,11 +2,18 @@ import adafruit_dht
 import threading
 from time import sleep
 from datetime import datetime
+import json
 
 class dhtData:
     def __init__(self, temperature, humidity):
         self.__temperature = temperature
         self.__humidity = humidity
+
+    def toJSON(self):
+        return json.dumps({
+            "temperature": self.temperature,
+            "humidity": self.humidity,
+        })
 
     @property
     def temperature(self):

--- a/run.py
+++ b/run.py
@@ -1,17 +1,31 @@
 from time import sleep
 import sys
+import threading
 from dependency_injector.wiring import Provide, inject
-
 from container import Container
+from flask import Flask, jsonify, Response
+from lib import clock, lcd, dht
+from api import api
+
+# @inject
+# def get_dht_data(dht : dht = Provide[Container.dht],):
+#     return Response(dht.data.toJSON(), mimetype="application/json")
 
 @inject
 def main(
-   lcd = Provide[Container.lcd],
-   dht = Provide[Container.dht],
-   clock = Provide[Container.clock],
+   lcd : lcd = Provide[Container.lcd],
+   dht : dht = Provide[Container.dht],
+   clock : clock = Provide[Container.clock],
+   api: api = Provide[Container.api],
 ) -> None:
   clock.run_async()
   dht.run_async()
+  api.run_async()
+  
+  # app = Flask(__name__)
+  # app.container = container
+  # app.add_url_rule("/dht", "dht", get_dht_data)
+  # threading.Thread(target=app.run, args=()).start()
 
   while True:
     if not dht.isRunning:
@@ -29,5 +43,4 @@ if __name__ == "__main__":
     container = Container()
     container.init_resources()
     container.wire(modules=[__name__])
-
     main(*sys.argv[1:])

--- a/run.py
+++ b/run.py
@@ -7,10 +7,6 @@ from flask import Flask, jsonify, Response
 from lib import clock, lcd, dht
 from api import api
 
-# @inject
-# def get_dht_data(dht : dht = Provide[Container.dht],):
-#     return Response(dht.data.toJSON(), mimetype="application/json")
-
 @inject
 def main(
    lcd : lcd = Provide[Container.lcd],
@@ -21,11 +17,6 @@ def main(
   clock.run_async()
   dht.run_async()
   api.run_async()
-  
-  # app = Flask(__name__)
-  # app.container = container
-  # app.add_url_rule("/dht", "dht", get_dht_data)
-  # threading.Thread(target=app.run, args=()).start()
 
   while True:
     if not dht.isRunning:


### PR DESCRIPTION
This pull request introduces a new API module to the application, which provides a JSON endpoint for the DHT data. The changes include the creation of a new `api` class, the addition of the `api` class to the dependency injection container, and modifications to the `dht` class and the `main` function to support the new API functionality.

New API functionality:

* [`api.py`](diffhunk://#diff-1ed02c3495a2cbdfb7310b80b4a533d180f77b750ebf1e23a86d0d93e5872178R1-R15): A new `api` class was added, which sets up a Flask application and provides a `/dht` endpoint that returns the DHT data in JSON format. The `api` class also includes a `run_async` method to run the Flask application in a separate thread.

Dependency injection changes:

* [`container.py`](diffhunk://#diff-e95207e1df7f5c5850ab1aa4833068c58447916ddf8031042d7a84f92c8f1501L2-R15): The `api` class was added to the dependency injection container. The `dht` class was also modified to be a singleton, similar to the `lcd` and `clock` classes.

DHT class changes:

* [`lib/dht.py`](diffhunk://#diff-75d5517cdac6035dce11a2a496208cd5b9e0c03ffa372aac816129a4ac258e1dR5-R17): A `toJSON` method was added to the `dhtData` class, which converts the DHT data to JSON format.

Main function changes:

* [`run.py`](diffhunk://#diff-d6af0459a37d985953d7040c14f53feb3b9cc9e58b543aa3c2b80256d276c5e0R3-R19): The `main` function was modified to include the `api` class in its parameters and to call the `run_async` method of the `api` class. This allows the Flask application to run in parallel with the other components of the application. [[1]](diffhunk://#diff-d6af0459a37d985953d7040c14f53feb3b9cc9e58b543aa3c2b80256d276c5e0R3-R19) [[2]](diffhunk://#diff-d6af0459a37d985953d7040c14f53feb3b9cc9e58b543aa3c2b80256d276c5e0L32)